### PR TITLE
Specify npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "node": ">=10"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@hubspot/local-dev-lib": "2.0.1"


### PR DESCRIPTION
## Description and Context
I am not 100% sure why this is happening, but running `npm publish` currently is trying to publish to https://registry.yarnpkg.com rather than npm. If I remember correctly, the same thing happened with LDL and this is how we solved it.

## Who to Notify
@brandenrodgers @kemmerle @joe-yeager 
