### PR TITLE
Add global config compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin makes it easy to use webpack-compiled assets in HubSpot CMS modules 
 
 ## Usage
 
-1. Set up a `hubspot.config.yml` using the HubSpot CMS local development [instructions](https://designers.hubspot.com/docs/tools/local-development).
+1. [Configure HubSpot local development tools](https://designers.hubspot.com/docs/tools/local-development).
 2. Add the plugin to your `webpack.config.js`. The `src` should be a path to the directory where the webpack compiled code is output and the `dest` property is the path where the assets should be uploaded in your HubSpot account.
 
 Example `webpack.config.js`

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@hubspot/local-dev-lib": "2.0.1"
+    "@hubspot/local-dev-lib": "3.7.1"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
## Description and Context
See #5 
`webpack-cms-plugins` was using an old version of `local-dev-lib`, which made it incompatible with the new global config file. This bumps the `local-dev-lib` dep to fix that issue.

## Who to Notify
@brandenrodgers @joe-yeager 
